### PR TITLE
fix: move functions to avoid circular dependencies

### DIFF
--- a/src/lib/series/legend.ts
+++ b/src/lib/series/legend.ts
@@ -1,7 +1,7 @@
-import { findDataSeriesByColorValues, getAxesSpecForSpecId } from '../../state/utils';
+import { getAxesSpecForSpecId } from '../../state/utils';
 import { identity } from '../utils/commons';
 import { AxisId, SpecId } from '../utils/ids';
-import { DataSeriesColorsValues, getSortedDataSeriesColorsValuesMap } from './series';
+import { DataSeriesColorsValues, findDataSeriesByColorValues, getSortedDataSeriesColorsValuesMap } from './series';
 import { AxisSpec, BasicSeriesSpec } from './specs';
 
 export interface LegendItem {

--- a/src/lib/series/rendering.ts
+++ b/src/lib/series/rendering.ts
@@ -1,5 +1,4 @@
 import { area, line } from 'd3-shape';
-import { mutableIndexedGeometryMapUpsert } from '../../state/utils';
 import { CanvasTextBBoxCalculator } from '../axes/canvas_text_bbox_calculator';
 import {
   AreaSeriesStyle,
@@ -98,6 +97,20 @@ export function isPointGeometry(ig: IndexedGeometry): ig is PointGeometry {
 }
 export function isBarGeometry(ig: IndexedGeometry): ig is BarGeometry {
   return ig.hasOwnProperty('width') && ig.hasOwnProperty('height');
+}
+
+export function mutableIndexedGeometryMapUpsert(
+  mutableGeometriesIndex: Map<any, IndexedGeometry[]>,
+  key: any,
+  geometry: IndexedGeometry | IndexedGeometry[],
+) {
+  const existing = mutableGeometriesIndex.get(key);
+  const upsertGeometry: IndexedGeometry[] = Array.isArray(geometry) ? geometry : [geometry];
+  if (existing === undefined) {
+    mutableGeometriesIndex.set(key, upsertGeometry);
+  } else {
+    mutableGeometriesIndex.set(key, [...upsertGeometry, ...existing]);
+  }
 }
 
 export function renderPoints(

--- a/src/lib/series/series.ts
+++ b/src/lib/series/series.ts
@@ -1,9 +1,9 @@
-import { findDataSeriesByColorValues } from '../../state/utils';
 import { ColorConfig } from '../themes/theme';
 import { Accessor } from '../utils/accessor';
 import { GroupId, SpecId } from '../utils/ids';
 import { splitSpecsByGroupId, YBasicSeriesSpec } from './domains/y_domain';
 import { formatNonStackedDataSeriesValues } from './nonstacked_series_utils';
+import { isEqualSeriesKey } from './series_utils';
 import { BasicSeriesSpec, Datum, SeriesAccessors } from './specs';
 import { formatStackedDataSeriesValues } from './stacked_series_utils';
 
@@ -62,6 +62,19 @@ export interface DataSeriesColorsValues {
   colorValues: any[];
   lastValue?: any;
   specSortIndex?: number;
+}
+
+export function findDataSeriesByColorValues(
+  series: DataSeriesColorsValues[] | null,
+  value: DataSeriesColorsValues,
+): number {
+  if (!series) {
+    return -1;
+  }
+
+  return series.findIndex((item: DataSeriesColorsValues) => {
+    return isEqualSeriesKey(item.colorValues, value.colorValues) && item.specId === value.specId;
+  });
 }
 
 /**

--- a/src/state/chart_state.ts
+++ b/src/state/chart_state.ts
@@ -23,6 +23,7 @@ import {
 import { countBarsInCluster } from '../lib/series/scales';
 import {
   DataSeriesColorsValues,
+  findDataSeriesByColorValues,
   FormattedDataSeries,
   getSeriesColorMap,
   RawDataSeries,
@@ -80,7 +81,6 @@ import {
   computeChartTransform,
   computeSeriesDomains,
   computeSeriesGeometries,
-  findDataSeriesByColorValues,
   getAxesSpecForSpecId,
   getUpdatedCustomSeriesColors,
   isChartAnimatable,

--- a/src/state/utils.test.ts
+++ b/src/state/utils.test.ts
@@ -1,6 +1,6 @@
 import { mergeDomainsByGroupId } from '../lib/axes/axis_utils';
 import { IndexedGeometry } from '../lib/series/rendering';
-import { DataSeriesColorsValues, getSeriesColorMap } from '../lib/series/series';
+import { DataSeriesColorsValues, findDataSeriesByColorValues, getSeriesColorMap } from '../lib/series/series';
 import {
   AreaSeriesSpec,
   AxisSpec,
@@ -15,7 +15,6 @@ import { ScaleType } from '../lib/utils/scales/scales';
 import {
   computeSeriesDomains,
   computeSeriesGeometries,
-  findDataSeriesByColorValues,
   getUpdatedCustomSeriesColors,
   isChartAnimatable,
   isHorizontalRotation,

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -7,6 +7,7 @@ import {
   BarGeometry,
   IndexedGeometry,
   LineGeometry,
+  mutableIndexedGeometryMapUpsert,
   PointGeometry,
   renderArea,
   renderBars,
@@ -16,12 +17,12 @@ import { computeXScale, computeYScales, countBarsInCluster } from '../lib/series
 import {
   DataSeries,
   DataSeriesColorsValues,
+  findDataSeriesByColorValues,
   FormattedDataSeries,
   getColorValuesAsString,
   getFormattedDataseries,
   getSplittedSeries,
 } from '../lib/series/series';
-import { isEqualSeriesKey } from '../lib/series/series_utils';
 import {
   AreaSeriesSpec,
   AxisSpec,
@@ -60,19 +61,6 @@ export interface GeometriesCounts {
   areasPoints: number;
   lines: number;
   linePoints: number;
-}
-
-export function findDataSeriesByColorValues(
-  series: DataSeriesColorsValues[] | null,
-  value: DataSeriesColorsValues,
-): number {
-  if (!series) {
-    return -1;
-  }
-
-  return series.findIndex((item: DataSeriesColorsValues) => {
-    return isEqualSeriesKey(item.colorValues, value.colorValues) && item.specId === value.specId;
-  });
 }
 
 export function updateDeselectedDataSeries(
@@ -530,20 +518,6 @@ export function mergeGeometriesIndexes(...iterables: Array<Map<any, IndexedGeome
     }
   }
   return geometriesIndex;
-}
-
-export function mutableIndexedGeometryMapUpsert(
-  mutableGeometriesIndex: Map<any, IndexedGeometry[]>,
-  key: any,
-  geometry: IndexedGeometry | IndexedGeometry[],
-) {
-  const existing = mutableGeometriesIndex.get(key);
-  const upsertGeometry: IndexedGeometry[] = Array.isArray(geometry) ? geometry : [geometry];
-  if (existing === undefined) {
-    mutableGeometriesIndex.set(key, upsertGeometry);
-  } else {
-    mutableGeometriesIndex.set(key, [...upsertGeometry, ...existing]);
-  }
 }
 
 export function isHorizontalRotation(chartRotation: Rotation) {


### PR DESCRIPTION
This avoids the circular dependencies caused by `utils` relying on and exporting functions used in `series/rendering.js` and `series/series.js`.  The functions that were moved were also related to rendering or series computations so it seemed ok to move them into those files and not just arbitrarily grouping them in their.

```
ERROR in Circular dependency detected:
../../elastic-charts/dist/lib/series/rendering.js -> ../../elastic-charts/dist/state/utils.js -> ../../elastic-charts/dist/lib/series/rendering.js

ERROR in Circular dependency detected:
../../elastic-charts/dist/lib/series/series.js -> ../../elastic-charts/dist/state/utils.js -> ../../elastic-charts/dist/lib/series/series.js

ERROR in Circular dependency detected:
../../elastic-charts/dist/state/utils.js -> ../../elastic-charts/dist/lib/series/rendering.js -> ../../elastic-charts/dist/state/utils.js
```